### PR TITLE
fix: Weblate ECS task configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,15 @@ WEBLATE_SERVER_EMAIL=weblate@example.com
 WEBLATE_DEFAULT_FROM_EMAIL=weblate@example.com
 WEBLATE_ALLOWED_HOSTS=*
 WEBLATE_REGISTRATION_OPEN=0
+SESSION_COOKIE_SECURE=True
+SECURE_SSL_REDIRECT=True
 
 # PostgreSQL setup
 POSTGRES_PASSWORD=weblate
 POSTGRES_USER=weblate
 POSTGRES_DATABASE=weblate
 POSTGRES_HOST=database
-POSTGRES_PORT=
+POSTGRES_PORT=5432
 
 # Cache setup
 # https://docs.weblate.org/en/latest/admin/install.html#production-cache

--- a/terraform/aws/ecs/ecs.tf
+++ b/terraform/aws/ecs/ecs.tf
@@ -8,11 +8,12 @@ module "localisation_services" {
   task_memory  = 4096
 
   # Task definition
-  container_image       = var.ecr_repository_url_weblate
+  container_image       = "${var.ecr_repository_url_weblate}:latest"
   container_host_port   = 4443
   container_port        = 4443
   container_environment = local.container_environment
   container_secrets     = local.container_secrets
+
   task_exec_role_policy_documents = [
     data.aws_iam_policy_document.ssm_parameters.json
   ]

--- a/terraform/aws/ecs/locals.tf
+++ b/terraform/aws/ecs/locals.tf
@@ -37,23 +37,47 @@ locals {
       "value" = "0"
     },
     {
+      "name"  = "WEBLATE_ENABLE_HTTPS",
+      "value" = "1"
+    },
+    {
       "name"  = "POSTGRES_DATABASE",
       "value" = "weblate"
     },
     {
+      "name"  = "POSTGRES_PORT",
+      "value" = "5432"
+    },
+    {
+      "name"  = "REDIS_DB",
+      "value" = "0"
+    },
+    {
+      "name"  = "REDIS_PORT",
+      "value" = "6379"
+    },
+    {
+      "name"  = "REDIS_TLS",
+      "value" = "1"
+    },
+    {
+      "name"  = "SESSION_COOKIE_SECURE",
+      "value" = "True"
+    },
+    {
+      "name"  = "SECURE_SSL_REDIRECT",
+      "value" = "True"
+    },
+    {
       "name"  = "CLIENT_MAX_BODY_SIZE",
       "value" = "200M"
-    }
+    },
   ]
 
   container_secrets = [
     {
-      "name"      = "WEBLATE_ADMIN_EMAIL",
-      "valueFrom" = aws_ssm_parameter.weblate_admin_email.arn,
-    },
-    {
-      "name"      = "WEBLATE_ADMIN_PASSWORD",
-      "valueFrom" = aws_ssm_parameter.weblate_admin_password.arn
+      "name"      = "POSTGRES_HOST",
+      "valueFrom" = var.weblate_database_host_secret_arn
     },
     {
       "name"      = "POSTGRES_PASSWORD",
@@ -64,16 +88,20 @@ locals {
       "valueFrom" = var.weblate_database_username_secret_arn
     },
     {
-      "name"      = "POSTGRES_HOST",
-      "valueFrom" = var.weblate_database_host_secret_arn
-    },
-    {
       "name"      = "REDIS_HOST",
       "valueFrom" = var.weblate_redis_url_secret_arn
     },
     {
       "name"      = "REDIS_PASSWORD",
       "valueFrom" = var.weblate_redis_auth_token_secret_arn
+    },
+    {
+      "name"      = "WEBLATE_ADMIN_EMAIL",
+      "valueFrom" = aws_ssm_parameter.weblate_admin_email.arn,
+    },
+    {
+      "name"      = "WEBLATE_ADMIN_PASSWORD",
+      "valueFrom" = aws_ssm_parameter.weblate_admin_password.arn
     },
   ]
 }

--- a/terraform/aws/load_balancer/load_balancer.tf
+++ b/terraform/aws/load_balancer/load_balancer.tf
@@ -21,7 +21,7 @@ resource "aws_lb" "localisation" {
 }
 
 resource "random_string" "alb_tg_suffix" {
-  length  = 4
+  length  = 3
   special = false
   upper   = false
 }
@@ -35,14 +35,10 @@ resource "aws_lb_target_group" "localisation" {
   vpc_id               = var.vpc_id
 
   health_check {
-    enabled             = true
-    interval            = 10
-    protocol            = "HTTPS"
-    path                = "/"
-    matcher             = "200-399"
-    timeout             = 5
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
+    enabled  = true
+    protocol = "HTTPS"
+    path     = "/healthz"
+    matcher  = "200-399"
   }
 
   stickiness {
@@ -75,24 +71,6 @@ resource "aws_lb_listener" "localisation" {
     aws_acm_certificate_validation.localisation,
     aws_route53_record.localisation_validation,
   ]
-
-  tags = var.common_tags
-}
-
-resource "aws_alb_listener_rule" "localisation" {
-  listener_arn = aws_lb_listener.localisation.arn
-  priority     = 100
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.localisation.arn
-  }
-
-  condition {
-    host_header {
-      values = [var.domain]
-    }
-  }
 
   tags = var.common_tags
 }

--- a/terraform/aws/redis/outputs.tf
+++ b/terraform/aws/redis/outputs.tf
@@ -3,11 +3,6 @@ output "weblate_redis_auth_token_secret_arn" {
   value       = aws_ssm_parameter.weblate_redis_auth_token.arn
 }
 
-output "weblate_redis_throttle_url_secret_arn" {
-  description = "ARN of the Weblate Redis throttle URL SSM Parameter"
-  value       = aws_ssm_parameter.weblate_redis_throttle_url.arn
-}
-
 output "weblate_redis_url_secret_arn" {
   description = "ARN of the Weblate Redis URL SSM Parameter"
   value       = aws_ssm_parameter.weblate_redis_url.arn

--- a/terraform/aws/redis/ssm.tf
+++ b/terraform/aws/redis/ssm.tf
@@ -5,16 +5,9 @@ resource "aws_ssm_parameter" "weblate_redis_auth_token" {
   tags  = var.common_tags
 }
 
-resource "aws_ssm_parameter" "weblate_redis_throttle_url" {
-  name  = "weblate-redis-throttle-url"
-  type  = "SecureString"
-  value = "redis://${aws_elasticache_replication_group.weblate.primary_endpoint_address}/1"
-  tags  = var.common_tags
-}
-
 resource "aws_ssm_parameter" "weblate_redis_url" {
   name  = "weblate-redis-url"
   type  = "SecureString"
-  value = "redis://${aws_elasticache_replication_group.weblate.primary_endpoint_address}"
+  value = aws_elasticache_replication_group.weblate.primary_endpoint_address
   tags  = var.common_tags
 }


### PR DESCRIPTION
# Summary
Update the Webate ECS task definition with the following:

1. Require TLS for Redis connections.
2. Update the Redis URL to no longer include the protocol.
3. Enable and require TLS and secure cookies.

This change also removes an ALB listener rule that was not required.

# ⚠️  Note
This change were applied locally to test so there should be no TF plan.

# Related
- https://github.com/cds-snc/platform-core-services/issues/480