### PR TITLE
feat: add volume and bind mount config

### DIFF
--- a/terraform/aws/ecs/ecs.tf
+++ b/terraform/aws/ecs/ecs.tf
@@ -15,7 +15,7 @@ module "localisation_services" {
   container_secrets     = local.container_secrets
   container_mount_points = [{
     sourceVolume  = local.efs_app_data_name
-    containerPath = local.efs_app_data_root_directory
+    containerPath = "/app/data"
     readOnly      = false
   }]
 

--- a/terraform/aws/ecs/ecs.tf
+++ b/terraform/aws/ecs/ecs.tf
@@ -1,5 +1,5 @@
 module "localisation_services" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=v7.2.9"
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=v7.2.10"
 
   # General
   cluster_name = "localisation-services"
@@ -13,6 +13,21 @@ module "localisation_services" {
   container_port        = 4443
   container_environment = local.container_environment
   container_secrets     = local.container_secrets
+  container_mount_points = [{
+    sourceVolume  = local.efs_app_data_name
+    containerPath = local.efs_app_data_root_directory
+    readOnly      = false
+  }]
+
+  task_volume = [{
+    name = local.efs_app_data_name
+    efs_volume_configuration = {
+      file_system_id          = aws_efs_file_system.weblate_data.id
+      root_directory          = local.efs_app_data_root_directory
+      transit_encryption      = "ENABLED"
+      transit_encryption_port = 2049
+    }
+  }]
 
   task_exec_role_policy_documents = [
     data.aws_iam_policy_document.ssm_parameters.json

--- a/terraform/aws/ecs/ecs.tf
+++ b/terraform/aws/ecs/ecs.tf
@@ -1,5 +1,5 @@
 module "localisation_services" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=v7.2.10"
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=v7.2.11"
 
   # General
   cluster_name = "localisation-services"
@@ -23,14 +23,21 @@ module "localisation_services" {
     name = local.efs_app_data_name
     efs_volume_configuration = {
       file_system_id          = aws_efs_file_system.weblate_data.id
-      root_directory          = local.efs_app_data_root_directory
       transit_encryption      = "ENABLED"
       transit_encryption_port = 2049
+      authorization_config = {
+        access_point_id = aws_efs_access_point.weblate_data.id
+        iam             = "ENABLED"
+      }
     }
   }]
 
   task_exec_role_policy_documents = [
     data.aws_iam_policy_document.ssm_parameters.json
+  ]
+
+  task_role_policy_documents = [
+    data.aws_iam_policy_document.efs_mount.json
   ]
 
   # Scaling

--- a/terraform/aws/ecs/efs.tf
+++ b/terraform/aws/ecs/efs.tf
@@ -77,7 +77,7 @@ resource "aws_efs_access_point" "weblate_data" {
     creation_info {
       owner_gid   = 1000
       owner_uid   = 1000
-      permissions = 750
+      permissions = 775
     }
   }
   tags = var.common_tags

--- a/terraform/aws/ecs/iam.tf
+++ b/terraform/aws/ecs/iam.tf
@@ -19,3 +19,17 @@ data "aws_iam_policy_document" "ssm_parameters" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "efs_mount" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "elasticfilesystem:ClientWrite",
+      "elasticfilesystem:ClientMount",
+      "elasticfilesystem:DescribeMountTargets",
+    ]
+    resources = [
+      aws_efs_file_system.weblate_data.arn
+    ]
+  }
+}

--- a/terraform/aws/ecs/locals.tf
+++ b/terraform/aws/ecs/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  efs_app_data_name           = "efs-app-data"
+  efs_app_data_root_directory = "/app/data"
+
   container_environment = [
     {
       "name"  = "WEBLATE_DEBUG",

--- a/terraform/aws/ecs/locals.tf
+++ b/terraform/aws/ecs/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  efs_app_data_name           = "efs-app-data"
-  efs_app_data_root_directory = "/app/data"
+  efs_app_data_name = "efs-app-data"
 
   container_environment = [
     {

--- a/weblate/docker/Dockerfile
+++ b/weblate/docker/Dockerfile
@@ -1,16 +1,21 @@
 FROM weblate/weblate:5.1@sha256:7664cf1ff6116db1bf770826f4e97d9459d6d61235ac658e41358862ccc9905f
 
 # Self-signed cert used for HTTPS between the load balancer and ECS task
-RUN mkdir -p /app/data/ssl \
-    && chown weblate:1000 /app/data/ssl \
+RUN mkdir -p /tmp/ssl \
+    && chown 1000:1000 /tmp/ssl \
     && openssl req -x509 \
         -newkey rsa:4096 \
-        -keyout /app/data/ssl/privkey.pem \
-        -out /app/data/ssl/fullchain.pem \
+        -keyout /tmp/ssl/privkey.pem \
+        -out /tmp/ssl/fullchain.pem \
         -sha256 \
         -days 3650 \
         -nodes \
         -subj "/C=CA/ST=Ontario/L=Ottawa/O=Government of Canada/OU=Canadian Digital Service/CN=localhost" \
-    && chmod 600 /app/data/ssl/*.pem
+    && chmod 600 /tmp/ssl/*.pem
+
+COPY --chown=1000:1000 bin/start-ssl.sh /app/bin/start-ssl
 
 USER 1000
+
+ENTRYPOINT ["/app/bin/start-ssl"]
+CMD ["runserver"]

--- a/weblate/docker/bin/start-ssl.sh
+++ b/weblate/docker/bin/start-ssl.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+COMMAND="$1"
+
+echo "Moving SSL certificates into the shared volume..."
+mkdir -p /app/data/ssl
+mv /tmp/ssl/*.pem /app/data/ssl/
+
+# Start Weblate
+echo "Starting Weblate $COMMAND..."
+/app/bin/start "$COMMAND"


### PR DESCRIPTION
# Summary
Update the ECS task with the volume and bind mount config that will be used to share the `/app/data` EFS volume with the ECS tasks.

As part of this change, a custom `ENTRYPOINT` script has been added that copies the self-signed SSL certificates into the shared `/app/data` volume on startup.

# ⚠️  Note
This was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/480