### PR TITLE
feat: Add a localization user and send deploy stats to sentinel

### DIFF
--- a/.github/workflows/terraform-apply-staging.yml
+++ b/.github/workflows/terraform-apply-staging.yml
@@ -69,4 +69,16 @@ jobs:
 
       - name: Apply ecs
         working-directory: terraform/env/staging/ecs
-        run: terragrunt apply --terragrunt-non-interactive -auto-approve        
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply translate
+        working-directory: terraform/env/staging/translate
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Report deployment to Sentinel
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          input_data: '{"product": "localisation", "sha": "${{ github.sha }}", "version": "POC", "repository": "${{ github.repository }}", "environment": "staging"}'
+          log_type: CDS_Product_Deployment_Data
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/.github/workflows/terraform-apply-staging.yml
+++ b/.github/workflows/terraform-apply-staging.yml
@@ -72,7 +72,7 @@ jobs:
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply translate
-        working-directory: terraform/env/staging/translate
+        working-directory: terraform/env/staging/translation
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Report deployment to Sentinel

--- a/.github/workflows/terraform-plan-staging.yml
+++ b/.github/workflows/terraform-plan-staging.yml
@@ -38,7 +38,7 @@ jobs:
           - module: network
           - module: redis
           - module: route53
-          - module: translate
+          - module: translation
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/terraform-plan-staging.yml
+++ b/.github/workflows/terraform-plan-staging.yml
@@ -38,6 +38,7 @@ jobs:
           - module: network
           - module: redis
           - module: route53
+          - module: translate
 
     runs-on: ubuntu-latest
     steps:

--- a/terraform/aws/translation/main.tf
+++ b/terraform/aws/translation/main.tf
@@ -1,0 +1,22 @@
+## The AWS Translate API needs to be enabled in the AWS console
+## The IAM User is entered into the Weblate UI, there is no automated way to inject this.
+
+resource "aws_iam_user" "automatic_suggestion_weblate" {
+  name = "AutomaticSuggestionWeblate"
+}
+
+resource "aws_iam_access_key" "weblate" { 
+  user = aws_iam_user.automatic_suggestion_weblate.name
+  status = "Active"
+}
+
+data "aws_iam_policy" "translate_full_access" { 
+  name = "TranslateFullAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "translate_full_access" {
+  user       = aws_iam_user.automatic_suggestion_weblate.name
+  policy_arn = data.aws_iam_policy.translate_full_access.arn
+}
+
+

--- a/terraform/aws/translation/main.tf
+++ b/terraform/aws/translation/main.tf
@@ -5,18 +5,27 @@ resource "aws_iam_user" "automatic_suggestion_weblate" {
   name = "AutomaticSuggestionWeblate"
 }
 
-resource "aws_iam_access_key" "weblate" { 
-  user = aws_iam_user.automatic_suggestion_weblate.name
+resource "aws_iam_group" "weblate_translation" {
+  name = "WeblateTranslation"
+}
+
+resource "aws_iam_user_group_membership" "weblate_translation_automatic_suggestion" {
+  user   = aws_iam_user.automatic_suggestion_weblate.name
+  groups = [aws_iam_group.weblate_translation.name]
+}
+
+resource "aws_iam_access_key" "weblate" {
+  user   = aws_iam_user.automatic_suggestion_weblate.name
   status = "Active"
 }
 
-data "aws_iam_policy" "translate_full_access" { 
+data "aws_iam_policy" "translate_full_access" {
   name = "TranslateFullAccess"
 }
 
-resource "aws_iam_user_policy_attachment" "translate_full_access" {
-  user       = aws_iam_user.automatic_suggestion_weblate.name
+
+resource "aws_iam_group_policy_attachment" "translate_full_access" {
+  group      = aws_iam_group.weblate_translation.name
   policy_arn = data.aws_iam_policy.translate_full_access.arn
 }
-
 

--- a/terraform/env/staging/translation/.terraform.lock.hcl
+++ b/terraform/env/staging/translation/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.23.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:AwjyBYctD8UKCXcm+kLJfRjYdUYzG0hetStKrw8UL9M=",
+    "zh:100966f25b1878b7c4ee250dcbaf09e5a2dad4bcebba2482d77c4cc4e48957da",
+    "zh:57ed5e66949568d25788ebcd170abf5961f81bb141f69d3acca9a7454994d0c5",
+    "zh:5acf55f8901d5443b6994463d7b2dcbb137a242486f47963e0f33c4cce30171a",
+    "zh:7036770df1223d15e0982be39bedf32b2e2cae1eabac717138cbc90bbf94e30e",
+    "zh:79f3f151984a97a7dee14e74ca9d9926b2add30982fe44a450645b89a6da6e00",
+    "zh:8a1b0bc5e237609fc1ad7af17e15a95f93a56c3403c0d022d94163ac1989507c",
+    "zh:94f3baf6a3ba728e31844d6786dae9aa505323389c6323e2eb820a3c81e82229",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ac4059a4f45c77432897605efb3642451c125ddddabe14d36a4a85dad13ae6cb",
+    "zh:d2a8d1c9a9100ae3fec34f119d3a90faefb89bf93780fc6934898533c6900cba",
+    "zh:de647167adb585a54cfbfc4c5d204c5d0a444624d386a773eae75789aa75f363",
+    "zh:edb533b3df81f2d1ef7387380cab843877f3f3c756f7a87cbba1961b3f01e4a2",
+    "zh:f56491ecb31b1ebde35cbfe8261e3c82c983b3039837f8756834cf27018bd93a",
+    "zh:fba46b50c35e40ea27947f4305320aaa61cdc22812b138571841e9bf8c7f5db9",
+    "zh:fcb92b5c6fbb70ae9137291ffc8ef06c48daec9cf0fafb980d178fe925658160",
+  ]
+}

--- a/terraform/env/staging/translation/terragrunt.hcl
+++ b/terraform/env/staging/translation/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//translation"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
The translate service seems to only be able to be enabled through the console.

The user was created using click-ops and then imported into state, there should be no terraform changes in this PR.

This user has to be entered through the UI there is currently no way to do this using code.

Here is proof of life: 
![image](https://github.com/cds-snc/localisation-services/assets/87738/931cd368-cec2-4488-97ac-40eb994686ff)
